### PR TITLE
use Bundler's solution to the environment problem

### DIFF
--- a/lib/re/helperregistry.rb
+++ b/lib/re/helperregistry.rb
@@ -23,23 +23,11 @@
 require 'shellwords'
 
 class HelperRegistry
-  # This is because Bundler is a piece of shit.
-  # It pollutes the environments in ways that makes
-  # spawning a Ruby program from Ruby wildly unreliable
-  # unless you clear out as much as possible
+
   def start(cmd)
-    dir =
-      spawn(
-        { 'HOME' => ENV['HOME'],
-          'DISPLAY' => ENV['DISPLAY'],
-          'LANG' => ENV['LANG'],
-          'PATH' => ENV['PATH'] },
-        cmd,
-        {
-          unsetenv_others: true,
-          chdir: File.expand_path('~')
-        }
-      )
+    Bundler.with_original_env do
+      system(cmd)
+    end
   end
 
   def select_section(buffer)


### PR DESCRIPTION
Bundler has three methods to clear out it's changes to the environment: `Bundler.with_original_env`, `Bundler.with_clean_env`, and `Bundler.with_unbundled_env`. I think `with_original_env` would most closely match the expectations of someone running a helper script rather than a completely clean one or one modified by re. Though, now that I think about it, `with_unbundled_env` would allow us to pass information along to the helpers.

Edit: reading the code says `with_clean_env` is the same as `with_unbundled_env`.
https://docs.ruby-lang.org/en/master/Bundler.html#method-c-with_original_env
